### PR TITLE
feat(health): add /ready DB readiness probe + tests; document health endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,10 @@ npx prisma migrate deploy
 npm run dev
 # GET http://localhost:3000/health -> {"status":"ok"}
 ```
+
+### Health endpoints
+
+- `GET /health` → Liveness probe. Always returns `200 { "status": "ok" }`.
+- `GET /ready` → Readiness probe. Returns:
+  - `200 { "status": "ready" }` when the database responds,
+  - `503 { "error": { "message": "Not Ready", "code": "NOT_READY" } }` otherwise.

--- a/tests/health.ready.test.ts
+++ b/tests/health.ready.test.ts
@@ -1,0 +1,29 @@
+import { test, expect, beforeAll } from "vitest";
+import request from "supertest";
+
+let app: any;
+
+beforeAll(async () => {
+  // Ensure JWT env is present for modules that read on import
+  process.env.JWT_ACCESS_SECRET ??= "test-access";
+  process.env.JWT_REFRESH_SECRET ??= "test-refresh";
+  process.env.JWT_ACCESS_EXPIRY ??= "15m";
+  process.env.JWT_REFRESH_EXPIRY ??= "7d";
+
+  const mod = await import("../src/app.js");
+  app = mod.default;
+});
+
+test("GET /health -> 200 {status:'ok'}", async () => {
+  const r = await request(app).get("/health");
+  expect(r.status).toBe(200);
+  expect(r.body).toEqual({ status: "ok" });
+  expect(r.headers["x-request-id"]).toBeTruthy();
+});
+
+test("GET /ready -> 200 {status:'ready'} (DB reachable)", async () => {
+  const r = await request(app).get("/ready");
+  expect(r.status).toBe(200);
+  expect(r.body).toEqual({ status: "ready" });
+  expect(r.headers["x-request-id"]).toBeTruthy();
+});

--- a/tests/ready.negative.test.ts
+++ b/tests/ready.negative.test.ts
@@ -1,0 +1,33 @@
+import { test, expect, beforeAll, vi } from "vitest";
+import request from "supertest";
+
+let app: any;
+
+beforeAll(async () => {
+  // minimal env for modules that read on import
+  process.env.JWT_ACCESS_SECRET ??= "test-access";
+  process.env.JWT_REFRESH_SECRET ??= "test-refresh";
+  process.env.JWT_ACCESS_EXPIRY ??= "15m";
+  process.env.JWT_REFRESH_EXPIRY ??= "7d";
+
+  // Mock prisma to simulate DB outage for this test file
+  vi.mock("../src/lib/prisma.js", () => {
+    return {
+      prisma: {
+        $queryRaw: vi.fn().mockRejectedValue(new Error("db down")),
+      },
+    };
+  });
+
+  const mod = await import("../src/app.js");
+  app = mod.default;
+});
+
+test("GET /ready -> 503 when DB ping fails", async () => {
+  const r = await request(app).get("/ready");
+  expect(r.status).toBe(503);
+  expect(r.body).toEqual({
+    error: { message: "Not Ready", code: "NOT_READY" },
+  });
+  expect(r.headers["x-request-id"]).toBeTruthy();
+});


### PR DESCRIPTION
## Summary
Implements production-standard health checks:

- **`GET /health`** → Liveness probe, always returns `200 { "status": "ok" }`
- **`GET /ready`** → Readiness probe that pings the database via Prisma

## Changes
- **src/app.ts**
  - Added `/ready` endpoint using `await prisma.$queryRaw\`SELECT 1\``  
  - Returns `200` if DB responds, otherwise `503` with `{ error: { message: "Not Ready", code: "NOT_READY" } }`
- **tests/**
  - `health.ready.test.ts`: verifies `/health` and `/ready` success responses  
  - `ready.negative.test.ts`: mocks DB failure, expects 503 response
- **README.md**
  - Added documentation for `/health` and `/ready`

## Testing
```bash
npm test
curl http://localhost:3000/health
curl http://localhost:3000/ready