### PR TITLE
chore: add Github CI badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Express + Prisma + JWT API
 
+[![CI](https://github.com/lucanovello/starter-express-prisma-jwt/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/lucanovello/starter-express-prisma-jwt/actions/workflows/ci.yml)
+
 Production-style REST API built with Express 5 + TypeScript, Prisma/Postgres, Zod validation, JWT auth (access + rotating refresh), structured logging, and a small operational surface (health/ready/metrics/version).
 
 - Auth: access + refresh JWT, refresh rotation (reuse detection revokes all sessions), DB-backed sessions


### PR DESCRIPTION
## Summary

This pull request adds a CI status badge to the project's `README.md` to display the current build status from GitHub Actions.

## Changes

- Documentation improvement:
  * Added a GitHub Actions CI badge to the top of the `README.md` to indicate the current status of the main branch's continuous integration workflow.